### PR TITLE
v1.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,7 @@ harness = false
 [[bench]]
 name = "bench_set_seq"
 harness = false
+
+[[bench]]
+name = "bench_set_from"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scapegoat"
-version = "1.6.0"
+version = "1.7.0"
 authors = ["Tiemoko Ballo"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 # scapegoat
 
 [![crates.io](https://img.shields.io/crates/v/scapegoat.svg)](https://crates.io/crates/scapegoat)
+[![docs.rs](https://docs.rs/scapegoat/badge.svg)](https://docs.rs/scapegoat/)
 [![GitHub Actions](https://github.com/tnballo/scapegoat/workflows/test/badge.svg)](https://github.com/tnballo/scapegoat/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/tnballo/scapegoat/blob/master/LICENSE)
+[![Unsafe-Zero-Percent](https://img.shields.io/badge/Unsafety-0%25-brightgreen.svg)](https://github.com/tnballo/scapegoat/blob/master/src/lib.rs#L223)
 
 Ordered set and map data structures via an arena-based [scapegoat tree](https://people.csail.mit.edu/rivest/pubs/GR93.pdf) (memory-efficient, self-balancing binary search tree).
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ if let Some(three_val) = example.get_mut(&3) {
 
 // New message :)
 assert!(example
-    .iter()
-    .map(|(_, v)| *v)
+    .into_values()
     .collect::<SmallVec<[&str; REF_BUF_LEN]>>()
     .iter()
     .eq(["Leverage","your friend the","borrow checker","for","safety!"].iter()));

--- a/README.tpl
+++ b/README.tpl
@@ -1,6 +1,9 @@
 # {{crate}}
 
 [![crates.io](https://img.shields.io/crates/v/scapegoat.svg)](https://crates.io/crates/scapegoat)
+[![docs.rs](https://docs.rs/scapegoat/badge.svg)](https://docs.rs/scapegoat/)
 [![GitHub Actions](https://github.com/tnballo/scapegoat/workflows/test/badge.svg)](https://github.com/tnballo/scapegoat/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/tnballo/scapegoat/blob/master/LICENSE)
+[![Unsafe-Zero-Percent](https://img.shields.io/badge/Unsafety-0%25-brightgreen.svg)](https://github.com/tnballo/scapegoat/blob/master/src/lib.rs#L223)
 
 {{readme}}

--- a/benches/bench_set_from.rs
+++ b/benches/bench_set_from.rs
@@ -14,13 +14,13 @@ fn bench_from_rand(c: &mut Criterion) {
 
     c.bench_function("sgs_from_10_000_rand", |b| {
         b.iter(|| {
-           let _ = SGSet::from(rand_10k);
+            let _ = SGSet::from(rand_10k);
         })
     });
 
     c.bench_function("std_from_10_000_rand", |b| {
         b.iter(|| {
-           let _ = BTreeSet::from(rand_10k);
+            let _ = BTreeSet::from(rand_10k);
         })
     });
 }
@@ -30,13 +30,13 @@ fn bench_from_seq(c: &mut Criterion) {
 
     c.bench_function("sgs_from_10_000_seq", |b| {
         b.iter(|| {
-           let _ = SGSet::from(seq_10k);
+            let _ = SGSet::from(seq_10k);
         })
     });
 
     c.bench_function("std_from_10_000_seq", |b| {
         b.iter(|| {
-           let _ = BTreeSet::from(seq_10k);
+            let _ = BTreeSet::from(seq_10k);
         })
     });
 }

--- a/benches/bench_set_from.rs
+++ b/benches/bench_set_from.rs
@@ -1,0 +1,45 @@
+use std::collections::BTreeSet;
+use std::convert::TryInto;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use scapegoat::SGSet;
+
+mod test_data;
+use test_data::{RAND_10_000, SEQ_10_000};
+
+// Benches -------------------------------------------------------------------------------------------------------------
+
+fn bench_from_rand(c: &mut Criterion) {
+    let rand_10k: [usize; 10_000] = RAND_10_000.keys.clone().try_into().unwrap();
+
+    c.bench_function("sgs_from_10_000_rand", |b| {
+        b.iter(|| {
+           let _ = SGSet::from(rand_10k);
+        })
+    });
+
+    c.bench_function("std_from_10_000_rand", |b| {
+        b.iter(|| {
+           let _ = BTreeSet::from(rand_10k);
+        })
+    });
+}
+
+fn bench_from_seq(c: &mut Criterion) {
+    let seq_10k: [usize; 10_000] = SEQ_10_000.keys.clone().try_into().unwrap();
+
+    c.bench_function("sgs_from_10_000_seq", |b| {
+        b.iter(|| {
+           let _ = SGSet::from(seq_10k);
+        })
+    });
+
+    c.bench_function("std_from_10_000_seq", |b| {
+        b.iter(|| {
+           let _ = BTreeSet::from(seq_10k);
+        })
+    });
+}
+
+criterion_group!(benches, bench_from_rand, bench_from_seq);
+criterion_main!(benches);

--- a/benches/bench_set_rand.rs
+++ b/benches/bench_set_rand.rs
@@ -6,7 +6,8 @@ use scapegoat::SGSet;
 
 mod test_data;
 use test_data::{
-    RAND_100, RAND_10_000, RAND_1_000, SGS_100_RAND, SGS_10_000_RAND, SGS_1_000_RAND, STD_100_RAND, STD_10_000_RAND, STD_1_000_RAND,
+    RAND_100, RAND_10_000, RAND_1_000, SGS_100_RAND, SGS_10_000_RAND, SGS_1_000_RAND, STD_100_RAND,
+    STD_10_000_RAND, STD_1_000_RAND,
 };
 
 // Benches -------------------------------------------------------------------------------------------------------------

--- a/benches/bench_set_seq.rs
+++ b/benches/bench_set_seq.rs
@@ -6,7 +6,8 @@ use scapegoat::SGSet;
 
 mod test_data;
 use test_data::{
-    SEQ_100, SEQ_10_000, SEQ_1_000, SGS_100_SEQ, SGS_10_000_SEQ, SGS_1_000_SEQ, STD_100_SEQ, STD_10_000_SEQ, STD_1_000_SEQ,
+    SEQ_100, SEQ_10_000, SEQ_1_000, SGS_100_SEQ, SGS_10_000_SEQ, SGS_1_000_SEQ, STD_100_SEQ,
+    STD_10_000_SEQ, STD_1_000_SEQ,
 };
 
 // Benches -------------------------------------------------------------------------------------------------------------

--- a/examples/static_strs.rs
+++ b/examples/static_strs.rs
@@ -54,8 +54,7 @@ fn main() {
 
     // New message :)
     assert!(example
-        .iter()
-        .map(|(_, v)| *v)
+        .into_values()
         .collect::<SmallVec<[&str; REF_BUF_LEN]>>()
         .iter()
         .eq([

--- a/fuzz/fuzz_targets/sg_map.rs
+++ b/fuzz/fuzz_targets/sg_map.rs
@@ -26,6 +26,7 @@ enum MapMethod<K: Ord + Debug, V: Debug> {
     IsEmpty,
     Iter,
     IterMut,
+    Keys,
     LastKey,
     LastKeyValue,
     Len,
@@ -36,6 +37,8 @@ enum MapMethod<K: Ord + Debug, V: Debug> {
     RemoveEntry { key: K },
     Retain { rand_key: K },
     SplitOff { key: K },
+    Values,
+    ValuesMut,
     // Trait Equivalence -----------------------------------------------------------------------------------------------
     Clone,
     Debug,
@@ -179,6 +182,9 @@ fuzz_target!(|methods: Vec<MapMethod<usize, usize>>| {
             MapMethod::IterMut => {
                 assert!(sg_map.iter_mut().eq(bt_map.iter_mut()));
             },
+            MapMethod::Keys => {
+                assert!(sg_map.keys().eq(bt_map.keys()));
+            },
             MapMethod::LastKey => {
                 let len_old = checked_get_len(&sg_map, &bt_map);
 
@@ -303,6 +309,12 @@ fuzz_target!(|methods: Vec<MapMethod<usize, usize>>| {
                     sg_map.cmp(&sg_map_new),
                     bt_map.cmp(&bt_map_new),
                 );
+            },
+            MapMethod::Values => {
+                assert!(sg_map.values().eq(bt_map.values()));
+            },
+            MapMethod::ValuesMut => {
+                assert!(sg_map.values_mut().eq(bt_map.values_mut()));
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,7 @@ if let Some(three_val) = example.get_mut(&3) {
 
 // New message :)
 assert!(example
-    .iter()
-    .map(|(_, v)| *v)
+    .into_values()
     .collect::<SmallVec<[&str; REF_BUF_LEN]>>()
     .iter()
     .eq(["Leverage","your friend the","borrow checker","for","safety!"].iter()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,11 +234,10 @@ include!(concat!(env!("OUT_DIR"), "/consts.rs"));
 pub use crate::tree::{Node, NodeArena, NodeGetHelper, NodeRebuildHelper};
 
 mod tree;
-pub use crate::tree::SGErr;
-pub use crate::tree::SGTree;
+pub use crate::tree::{SGErr, SGTree};
 
 mod map;
-pub use crate::map::SGMap;
+pub use crate::map::{IntoKeys, Keys, SGMap};
 
 mod set;
 pub use crate::set::SGSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,7 @@ mod tree;
 pub use crate::tree::{SGErr, SGTree};
 
 mod map;
-pub use crate::map::{IntoKeys, Keys, SGMap};
+pub use crate::map::{IntoKeys, IntoValues, Keys, SGMap, Values, ValuesMut};
 
 mod set;
 pub use crate::set::SGSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,9 @@ Contributions are welcome!
 #![forbid(unsafe_code)]
 #![cfg_attr(not(any(test, fuzzing)), no_std)]
 #![cfg_attr(not(any(test, fuzzing)), deny(missing_docs))]
-#![doc(html_logo_url = "https://raw.githubusercontent.com/tnballo/scapegoat/master/img/scapegoat.svg")]
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/tnballo/scapegoat/master/img/scapegoat.svg"
+)]
 
 include!(concat!(env!("OUT_DIR"), "/consts.rs"));
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -56,6 +56,26 @@ impl<K: Ord, V> SGMap<K, V> {
         self.bst.set_rebal_param(alpha_num, alpha_denom)
     }
 
+    /// Get the current rebalance parameter, alpha, as a tuple of `(alpha_numerator, alpha_denominator)`.
+    /// See [the corresponding setter method][SGMap::set_rebal_param] for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scapegoat::SGMap;
+    ///
+    /// let mut map: SGMap<isize, isize> = SGMap::new();
+    ///
+    /// // Set 2/3, e.g. `a = 0.666...` (it's default value).
+    /// assert!(map.set_rebal_param(2.0, 3.0).is_ok());
+    ///
+    /// // Get the currently set value
+    /// assert_eq!(map.rebal_param(), (2.0, 3.0));
+    /// ```
+    pub fn rebal_param(&self) -> (f32, f32) {
+        self.bst.rebal_param()
+    }
+
     /// `#![no_std]`: total capacity, e.g. maximum number of map pairs.
     /// Attempting to insert pairs beyond capacity will panic, unless the `high_assurance` feature is enabled.
     ///

--- a/src/map.rs
+++ b/src/map.rs
@@ -137,6 +137,75 @@ impl<K: Ord, V> SGMap<K, V> {
         }
     }
 
+    /// Gets an iterator over the values of the map, in order by key.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use scapegoat::SGMap;
+    ///
+    /// let mut a = SGMap::new();
+    /// a.insert(1, "hello");
+    /// a.insert(2, "goodbye");
+    ///
+    /// let values: Vec<&str> = a.values().cloned().collect();
+    /// assert_eq!(values, ["hello", "goodbye"]);
+    /// ```
+    pub fn values(&self) -> Values<'_, K, V> {
+        Values { inner: self.iter() }
+    }
+
+    /// Creates a consuming iterator visiting all the values, in order by key.
+    /// The map cannot be used after calling this.
+    /// The iterator element type is `V`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scapegoat::SGMap;
+    ///
+    /// let mut a = SGMap::new();
+    /// a.insert(1, "hello");
+    /// a.insert(2, "goodbye");
+    ///
+    /// let values: Vec<&str> = a.into_values().collect();
+    /// assert_eq!(values, ["hello", "goodbye"]);
+    /// ```
+    pub fn into_values(self) -> IntoValues<K, V> {
+        IntoValues {
+            inner: self.into_iter(),
+        }
+    }
+
+    /// Gets a mutable iterator over the values of the map, in order by key.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use scapegoat::SGMap;
+    ///
+    /// let mut a = SGMap::new();
+    /// a.insert(1, String::from("hello"));
+    /// a.insert(2, String::from("goodbye"));
+    ///
+    /// for value in a.values_mut() {
+    ///     value.push_str("!");
+    /// }
+    ///
+    /// let values: Vec<String> = a.values().cloned().collect();
+    /// assert_eq!(values, [String::from("hello!"),
+    ///                     String::from("goodbye!")]);
+    /// ```
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
+        ValuesMut {
+            inner: self.iter_mut(),
+        }
+    }
+
     /// Moves all elements from `other` into `self`, leaving `other` empty.
     ///
     /// # Examples
@@ -828,7 +897,7 @@ impl<'a, K: Ord, V> Iterator for Keys<'a, K, V> {
 
 /// An owning iterator over the keys of a `SGMap`.
 ///
-/// This `struct` is created by the [`into_keys`][SGMap::into_keys] method on [`SGMap`].
+/// This `struct` is created by the [`into_keys`][SGMap::into_keys] method on [`SGMap`][SGMap].
 /// See its documentation for more.
 pub struct IntoKeys<K: Ord, V> {
     inner: IntoIter<K, V>,
@@ -845,3 +914,51 @@ impl<K: Ord, V> Iterator for IntoKeys<K, V> {
 // Value Iterators -----------------------------------------------------------------------------------------------------
 
 // TODO: these need more trait implementations for full compatibility
+
+/// An iterator over the values of a `SGMap`.
+///
+/// This `struct` is created by the [`values`][SGMap::values] method on [`SGMap`][SGMap].
+/// See its documentation for more.
+pub struct Values<'a, K: Ord + 'a, V: 'a> {
+    inner: Iter<'a, K, V>,
+}
+
+impl<'a, K: Ord, V> Iterator for Values<'a, K, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<&'a V> {
+        self.inner.next().map(|(_, v)| v)
+    }
+}
+
+/// An owning iterator over the values of a `SGMap`.
+///
+/// This `struct` is created by the [`into_values`][SGMap::into_values] method on [`SGMap`][SGMap].
+/// See its documentation for more.
+pub struct IntoValues<K: Ord, V> {
+    inner: IntoIter<K, V>,
+}
+
+impl<K: Ord, V> Iterator for IntoValues<K, V> {
+    type Item = V;
+
+    fn next(&mut self) -> Option<V> {
+        self.inner.next().map(|(_, v)| v)
+    }
+}
+
+/// A mutable iterator over the values of a `SGMap`.
+///
+/// This `struct` is created by the [`values_mut`][SGMap::values_mut] method on [`SGMap`][SGMap].
+/// See its documentation for more.
+pub struct ValuesMut<'a, K: Ord + 'a, V: 'a> {
+    inner: IterMut<'a, K, V>,
+}
+
+impl<'a, K: Ord, V> Iterator for ValuesMut<'a, K, V> {
+    type Item = &'a mut V;
+
+    fn next(&mut self) -> Option<&'a mut V> {
+        self.inner.next().map(|(_, v)| v)
+    }
+}

--- a/src/set.rs
+++ b/src/set.rs
@@ -56,6 +56,26 @@ impl<T: Ord> SGSet<T> {
         self.bst.set_rebal_param(alpha_num, alpha_denom)
     }
 
+    /// Get the current rebalance parameter, alpha, as a tuple of `(alpha_numerator, alpha_denominator)`.
+    /// See [the corresponding setter method][SGSet::set_rebal_param] for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scapegoat::SGSet;
+    ///
+    /// let mut set: SGSet<isize> = SGSet::new();
+    ///
+    /// // Set 2/3, e.g. `a = 0.666...` (it's default value).
+    /// assert!(set.set_rebal_param(2.0, 3.0).is_ok());
+    ///
+    /// // Get the currently set value
+    /// assert_eq!(set.rebal_param(), (2.0, 3.0));
+    /// ```
+    pub fn rebal_param(&self) -> (f32, f32) {
+        self.bst.rebal_param()
+    }
+
     /// `#![no_std]`: total capacity, e.g. maximum number of set elements.
     /// Attempting to insert elements beyond capacity will panic, unless the `high_assurance` feature is enabled.
     ///

--- a/src/set.rs
+++ b/src/set.rs
@@ -5,7 +5,7 @@ use core::iter::FromIterator;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
 
 use crate::tree::{
-    ConsumingIter as TreeConsumingIter, ElemRefIter, ElemRefVec, Iter as TreeIter, SGErr, SGTree,
+    ElemRefIter, ElemRefVec, IntoIter as TreeIntoIter, Iter as TreeIter, SGErr, SGTree,
 };
 
 /// Ordered set.
@@ -910,27 +910,27 @@ impl<'a, T: Ord> Iterator for Iter<'a, T> {
 // Consuming iterator
 impl<T: Ord> IntoIterator for SGSet<T> {
     type Item = T;
-    type IntoIter = ConsumingIter<T>;
+    type IntoIter = IntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        ConsumingIter::new(self)
+        IntoIter::new(self)
     }
 }
 
 /// Consuming iterator wrapper
-pub struct ConsumingIter<T: Ord> {
-    cons_iter: TreeConsumingIter<T, ()>,
+pub struct IntoIter<T: Ord> {
+    cons_iter: TreeIntoIter<T, ()>,
 }
 
-impl<T: Ord> ConsumingIter<T> {
+impl<T: Ord> IntoIter<T> {
     pub fn new(set: SGSet<T>) -> Self {
-        ConsumingIter {
-            cons_iter: TreeConsumingIter::new(set.bst),
+        IntoIter {
+            cons_iter: TreeIntoIter::new(set.bst),
         }
     }
 }
 
-impl<T: Ord> Iterator for ConsumingIter<T> {
+impl<T: Ord> Iterator for IntoIter<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/tree/iter.rs
+++ b/src/tree/iter.rs
@@ -103,14 +103,15 @@ impl<'a, K: Ord, V> Iterator for IterMut<'a, K, V> {
 
 /// Cheats a little by using internal flattening logic to sort, instead of re-implementing proper traversal.
 /// Maintains a shrinking list of arena indexes, initialized with all of them.
-pub struct ConsumingIter<K: Ord, V> {
+pub struct IntoIter<K: Ord, V> {
     bst: SGTree<K, V>,
     sorted_idxs: IdxVec,
 }
 
-impl<K: Ord, V> ConsumingIter<K, V> {
+impl<K: Ord, V> IntoIter<K, V> {
+    /// Constructor
     pub fn new(bst: SGTree<K, V>) -> Self {
-        let mut ordered_iter = ConsumingIter {
+        let mut ordered_iter = IntoIter {
             bst,
             sorted_idxs: IdxVec::new(),
         };
@@ -124,7 +125,7 @@ impl<K: Ord, V> ConsumingIter<K, V> {
     }
 }
 
-impl<K: Ord, V> Iterator for ConsumingIter<K, V> {
+impl<K: Ord, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -13,7 +13,7 @@ mod node;
 pub use node::{Node, NodeGetHelper, NodeRebuildHelper};
 
 mod iter;
-pub use iter::{ConsumingIter, Iter, IterMut};
+pub use iter::{IntoIter, Iter, IterMut};
 
 mod error;
 pub use error::SGErr;

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -8,7 +8,7 @@ use core::ops::Index;
 
 use super::arena::NodeArena;
 use super::error::SGErr;
-use super::iter::{ConsumingIter, Iter, IterMut};
+use super::iter::{IntoIter, Iter, IterMut};
 use super::node::{Node, NodeGetHelper, NodeRebuildHelper};
 use super::types::{
     Idx, IdxVec, RebuildMetaVec, SortMetaVec, SortNodeRefIdxPairVec, SortNodeRefVec,
@@ -1430,9 +1430,9 @@ impl<'a, K: Ord, V> IntoIterator for &'a SGTree<K, V> {
 // Consuming iterator
 impl<K: Ord, V> IntoIterator for SGTree<K, V> {
     type Item = (K, V);
-    type IntoIter = ConsumingIter<K, V>;
+    type IntoIter = IntoIter<K, V>;
 
     fn into_iter(self) -> Self::IntoIter {
-        ConsumingIter::new(self)
+        IntoIter::new(self)
     }
 }

--- a/src/tree/tree.rs
+++ b/src/tree/tree.rs
@@ -27,7 +27,7 @@ use smallvec::smallvec;
 pub struct SGTree<K: Ord, V> {
     // Storage
     pub(crate) arena: NodeArena<K, V>,
-    pub(crate) root_idx: Option<Idx>,
+    pub(crate) root_idx: Option<Idx>, // TODO: rename to opt_root_idx
 
     // Query cache
     max_idx: Idx,
@@ -91,6 +91,26 @@ impl<K: Ord, V> SGTree<K, V> {
             }
             false => Err(SGErr::RebalanceFactorOutOfRange),
         }
+    }
+
+    /// Get the current rebalance parameter, alpha, as a tuple of `(alpha_numerator, alpha_denominator)`.
+    /// See [the corresponding setter method][SGTree::set_rebal_param] for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use scapegoat::SGTree;
+    ///
+    /// let mut sgt: SGTree<isize, isize> = SGTree::new();
+    ///
+    /// // Set 2/3, e.g. `a = 0.666...` (it's default value).
+    /// assert!(sgt.set_rebal_param(2.0, 3.0).is_ok());
+    ///
+    /// // Get the currently set value
+    /// assert_eq!(sgt.rebal_param(), (2.0, 3.0));
+    /// ```
+    pub fn rebal_param(&self) -> (f32, f32) {
+        (self.alpha_num, self.alpha_denom)
     }
 
     /// `#![no_std]`: total capacity, e.g. maximum number of tree pairs.


### PR DESCRIPTION
* Performance optimization - up to 20% faster insert.
* Add map iterator convenience methods: `into_keys`, `keys`, `into_values`, `values`, `values_mut`.
* Add alpha param getter API: `rebal_param`.
* Bench for construction from static array (relevant to embedded use cases).