### PR TITLE
Implement `DoubleEndedIterator` on `RangeMut`

### DIFF
--- a/src/tree/iter.rs
+++ b/src/tree/iter.rs
@@ -115,6 +115,17 @@ impl<'a, K: Ord + Default, V: Default, const N: usize> Iterator for IterMut<'a, 
     }
 }
 
+impl<'a, K: Ord + Default, V: Default, const N: usize> DoubleEndedIterator
+    for IterMut<'a, K, V, N>
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self.arena_iter_mut.next_back() {
+            Some(Some(node)) => Some(node.get_mut()),
+            _ => None,
+        }
+    }
+}
+
 impl<'a, K: Ord + Default, V: Default, const N: usize> ExactSizeIterator for IterMut<'a, K, V, N> {
     fn len(&self) -> usize {
         self.arena_iter_mut.len()

--- a/tests/test_map_api.rs
+++ b/tests/test_map_api.rs
@@ -329,7 +329,12 @@ fn test_map_range_mut() {
         *val += 10;
     }
 
-    assert_eq!(map["a"], 0);
+    let mut iter_mut = map.range_mut("a"..="c").rev().map(|(k, v)| (*k, *v));
+
+    assert_eq!(iter_mut.next(), Some(("c", 0)));
+    assert_eq!(iter_mut.next(), Some(("b", 0)));
+    assert_eq!(iter_mut.next(), Some(("a", 0)));
+
     assert_eq!(map["c"], 0);
     assert_eq!(map["d"], 10);
     assert_eq!(map["e"], 10);


### PR DESCRIPTION
Kind of a hack since we don't have something like `peek_back()`, but it works. :smile: 
Would appreciate the feedback!