### PR TITLE
v2.2.1 + Changelog for v2.2.0, v2.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scapegoat"
-version = "2.2.0"
+version = "2.2.1"
 rust = "1.55"
 authors = ["Tiemoko Ballo"]
 edition = "2018"

--- a/src/map.rs
+++ b/src/map.rs
@@ -1051,9 +1051,10 @@ impl<K: Ord + Default, V: Default, const N: usize> SgMap<K, V, N> {
         K: Borrow<T> + Ord,
         R: RangeBounds<T>,
     {
+        SgTree::<K, V, N>::assert_valid_range(&range);
         Range {
             table: self,
-            node_idx_iter: self.bst.range_search(range).into_iter(),
+            node_idx_iter: self.bst.range_search(&range).into_iter(),
         }
     }
 
@@ -1096,6 +1097,7 @@ impl<K: Ord + Default, V: Default, const N: usize> SgMap<K, V, N> {
         K: Borrow<T> + Ord,
         R: RangeBounds<T>,
     {
+        SgTree::<K, V, N>::assert_valid_range(&range);
         RangeMut::new(self, &range)
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -683,6 +683,11 @@ impl<T: Ord + Default, const N: usize> SgSet<T, N> {
     /// `range((Excluded(4), Included(10)))` will yield a left-exclusive, right-inclusive
     /// range from 4 to 10.
     ///
+    /// # Panics
+    ///
+    /// Panics if range `start > end`.
+    /// Panics if range `start == end` and both bounds are `Excluded`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -704,9 +709,10 @@ impl<T: Ord + Default, const N: usize> SgSet<T, N> {
         T: Borrow<K> + Ord,
         R: RangeBounds<K>,
     {
+        SgTree::<T, (), N>::assert_valid_range(&range);
         Range {
             table: self,
-            node_idx_iter: self.bst.range_search(range).into_iter(),
+            node_idx_iter: self.bst.range_search(&range).into_iter(),
         }
     }
 

--- a/src/tree/arena.rs
+++ b/src/tree/arena.rs
@@ -431,4 +431,23 @@ mod tests {
         assert!(small_node_size < large_node_size);
         */
     }
+
+    #[test]
+    fn test_arena_next_back() {
+        let mut arena: Arena<usize, usize, small_unsigned!(CAPACITY), CAPACITY> = Arena::new();
+
+        assert_eq!(0, arena.add(0, 0));
+        assert_eq!(1, arena.add(1, 1));
+        assert_eq!(2, arena.add(2, 2));
+
+        assert_eq!(1, *arena.remove(1).unwrap().key());
+        assert_eq!(1, arena.add(3, 3));
+
+        let mut iter_mut = arena.iter_mut();
+        assert_eq!(iter_mut.len(), 3);
+        assert_eq!(&2, iter_mut.next_back().unwrap().as_ref().unwrap().key());
+        assert_eq!(&3, iter_mut.next_back().unwrap().as_ref().unwrap().key());
+        assert_eq!(&0, iter_mut.next_back().unwrap().as_ref().unwrap().key());
+        assert!(iter_mut.next_back().is_none());
+    }
 }

--- a/src/tree/test.rs
+++ b/src/tree/test.rs
@@ -758,3 +758,19 @@ fn test_capacity_exceed() {
     const OVER_CAP: usize = (Idx::MAX as usize) + 1;
     let _ = SgTree::<u8, u8, OVER_CAP>::new();
 }
+
+#[test]
+fn test_double_ended_iter_mut() {
+    // See: https://doc.rust-lang.org/std/iter/trait.DoubleEndedIterator.html
+    let mut sgt = SgTree::from([(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)]);
+    let mut iter = sgt.iter_mut();
+
+    assert_eq!(Some((&1, &mut 1)), iter.next());
+    assert_eq!(Some((&6, &mut 6)), iter.next_back());
+    assert_eq!(Some((&5, &mut 5)), iter.next_back());
+    assert_eq!(Some((&2, &mut 2)), iter.next());
+    assert_eq!(Some((&3, &mut 3)), iter.next());
+    assert_eq!(Some((&4, &mut 4)), iter.next());
+    assert_eq!(None, iter.next());
+    assert_eq!(None, iter.next_back());
+}

--- a/tests/test_map_api.rs
+++ b/tests/test_map_api.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
+use std::ops::Bound::{Excluded, Included};
 
 use scapegoat::{SgError, SgMap};
 
@@ -307,6 +308,8 @@ fn test_map_insert_panic() {
     a.insert(4, "4"); // panic
 }
 
+// Range APIs ----------------------------------------------------------------------------------------------------------
+
 #[test]
 fn test_map_range() {
     let array = [(1, "a"), (5, "e"), (3, "c"), (7, "g"), (9, "i")];
@@ -338,4 +341,84 @@ fn test_map_range_mut() {
     assert_eq!(map["c"], 0);
     assert_eq!(map["d"], 10);
     assert_eq!(map["e"], 10);
+}
+
+#[should_panic(expected = "range start is greater than range end in BTreeMap")]
+#[test]
+fn test_btree_map_range_panic_1() {
+    let mut map: BTreeMap<usize, usize> = BTreeMap::new();
+    map.insert(3, 3);
+    map.insert(5, 5);
+    map.insert(8, 8);
+    let _bad_range = map.range((Included(&8), Included(&3)));
+}
+
+#[should_panic(expected = "range start is greater than range end")]
+#[test]
+fn test_sg_map_range_panic_1() {
+    let mut map = SgMap::<usize, usize, DEFAULT_CAPACITY>::new();
+    map.insert(3, 3);
+    map.insert(5, 5);
+    map.insert(8, 8);
+    let _bad_range = map.range((Included(&8), Included(&3)));
+}
+
+#[should_panic(expected = "range start and end are equal and excluded in BTreeMap")]
+#[test]
+fn test_btree_map_range_panic_2() {
+    let mut map: BTreeMap<usize, usize> = BTreeMap::new();
+    map.insert(3, 3);
+    map.insert(5, 5);
+    map.insert(8, 8);
+    let _bad_range = map.range((Excluded(&5), Excluded(&5)));
+}
+
+#[should_panic(expected = "range start and end are equal and excluded")]
+#[test]
+fn test_sg_map_range_panic_2() {
+    let mut map = SgMap::<usize, usize, DEFAULT_CAPACITY>::new();
+    map.insert(3, 3);
+    map.insert(5, 5);
+    map.insert(8, 8);
+    let _bad_range = map.range((Excluded(&5), Excluded(&5)));
+}
+
+#[should_panic(expected = "range start is greater than range end in BTreeMap")]
+#[test]
+fn test_btree_map_range_mut_panic_1() {
+    let mut map: BTreeMap<usize, usize> = BTreeMap::new();
+    map.insert(3, 3);
+    map.insert(5, 5);
+    map.insert(8, 8);
+    let _bad_range = map.range_mut((Included(&8), Included(&3)));
+}
+
+#[should_panic(expected = "range start is greater than range end")]
+#[test]
+fn test_sg_map_range_mut_panic_1() {
+    let mut map = SgMap::<usize, usize, DEFAULT_CAPACITY>::new();
+    map.insert(3, 3);
+    map.insert(5, 5);
+    map.insert(8, 8);
+    let _bad_range = map.range_mut((Included(&8), Included(&3)));
+}
+
+#[should_panic(expected = "range start and end are equal and excluded in BTreeMap")]
+#[test]
+fn test_btree_map_range_mut_panic_2() {
+    let mut map: BTreeMap<usize, usize> = BTreeMap::new();
+    map.insert(3, 3);
+    map.insert(5, 5);
+    map.insert(8, 8);
+    let _bad_range = map.range_mut((Excluded(&5), Excluded(&5)));
+}
+
+#[should_panic(expected = "range start and end are equal and excluded")]
+#[test]
+fn test_sg_map_range_mut_panic_2() {
+    let mut map = SgMap::<usize, usize, DEFAULT_CAPACITY>::new();
+    map.insert(3, 3);
+    map.insert(5, 5);
+    map.insert(8, 8);
+    let _bad_range = map.range_mut((Excluded(&5), Excluded(&5)));
 }


### PR DESCRIPTION
**v2.2.1**

- Impl `DoubleEndedIterator` for `SgMap`'s `range_mut` (#20)
- Ensure this library's `range` and `range_mut` APIs matches `std`'s panic semantics (e.g. "Panics if range `start > end`. Panics if range `start == end` and both bounds are `Excluded`."

**v2.2.0**

- Add map/set `range` APIs (#19)

**v2.1.0**

- Add map's `Entry` APIs (#16)